### PR TITLE
chore: cleaning up staticcheck issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /local.yaml
 /dev.yaml
 demo/
+
+.envrc
+.vscode
+
+harness-upgrade

--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -157,7 +156,7 @@ func GetWithAuth(host string, query string, authMethod string, base64Auth string
 	defer resp.Body.Close()
 
 	// Read and print the response body
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Error reading response body:", err)
 		return nil, err

--- a/constants.go
+++ b/constants.go
@@ -18,7 +18,7 @@ const (
 )
 
 const (
-	Project string = "project"
+	Project        = "project"
 	Org            = "org"
 	Account        = "account"
 )
@@ -37,5 +37,8 @@ const (
 
 const (
 	AccountScope TemplateScope = "ACCOUNT"
+)
+
+const (
 	AppScope                   = "APP"
 )

--- a/constants.go
+++ b/constants.go
@@ -18,9 +18,9 @@ const (
 )
 
 const (
-	Project        = "project"
-	Org            = "org"
-	Account        = "account"
+	Project = "project"
+	Org     = "org"
+	Account = "account"
 )
 
 const (
@@ -40,5 +40,5 @@ const (
 )
 
 const (
-	AppScope                   = "APP"
+	AppScope = "APP"
 )

--- a/expressions.go
+++ b/expressions.go
@@ -360,9 +360,7 @@ func getDynamicExpressionValue(key string) string {
 	var dynamic string
 	if strings.HasSuffix(k, "(") {
 		dynamic = strings.Replace(key, k, "", 1)
-		if strings.HasSuffix(dynamic, ")") {
-			dynamic = dynamic[0 : len(dynamic)-1]
-		}
+		dynamic = strings.TrimSuffix(dynamic, ")")
 	} else {
 		dynamic = strings.Replace(key, k+".", "", 1)
 	}
@@ -370,7 +368,7 @@ func getDynamicExpressionValue(key string) string {
 }
 
 func getDynamicExpressionKey(key string) string {
-	for exp, _ := range DynamicExpressions {
+	for exp := range DynamicExpressions {
 		if strings.HasPrefix(key, exp) {
 			return exp
 		}

--- a/helper.go
+++ b/helper.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	Prod        string = "Prod"
+	Prod               = "Prod"
 	QA                 = "QA"
 	Dev                = "Dev"
 	Prod3              = "Prod3"
@@ -28,7 +28,7 @@ const (
 )
 
 const (
-	MigratorService string = "Migrator"
+	MigratorService        = "Migrator"
 	NextGenService         = "NextGen"
 	TemplateService        = "Template"
 	PipelineService        = "Pipeline"
@@ -153,7 +153,7 @@ func Set(str []string) []string {
 	for _, val := range str {
 		dict[val] = true
 	}
-	for k, _ := range dict {
+	for k := range dict {
 		result = append(result, k)
 	}
 	return result
@@ -512,14 +512,14 @@ func LoadCustomeStringsFromFile(filePath string) map[string]string {
 	// Read the entire file
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		fmt.Sprintf("error reading file: %v", err)
+		log.Info(fmt.Sprintf("error reading file: %v", err))
 	}
 
 	// Unmarshal YAML content into a slice of maps
 	var replaceSections []map[string]string
 	err = yaml.Unmarshal(content, &replaceSections)
 	if err != nil {
-		fmt.Sprintf("error unmarshalling YAML: %v", err)
+		log.Info(fmt.Sprintf("error unmarshalling YAML: %v", err))
 	}
 
 	// Create a map to store the accumulated sections
@@ -535,7 +535,7 @@ func LoadCustomeStringsFromFile(filePath string) map[string]string {
 			delete(replaceSection, "new")
 			mergedSections[oldValue] = newValue
 		} else {
-			fmt.Sprintf("'old' or 'new' keys not found in a section")
+			log.Info("'old' or 'new' keys not found in a section")
 		}
 	}
 	return mergedSections

--- a/helper.go
+++ b/helper.go
@@ -20,18 +20,18 @@ import (
 )
 
 const (
-	Prod               = "Prod"
-	QA                 = "QA"
-	Dev                = "Dev"
-	Prod3              = "Prod3"
-	SelfManaged        = "SelfManaged"
+	Prod        = "Prod"
+	QA          = "QA"
+	Dev         = "Dev"
+	Prod3       = "Prod3"
+	SelfManaged = "SelfManaged"
 )
 
 const (
-	MigratorService        = "Migrator"
-	NextGenService         = "NextGen"
-	TemplateService        = "Template"
-	PipelineService        = "Pipeline"
+	MigratorService = "Migrator"
+	NextGenService  = "NextGen"
+	TemplateService = "Template"
+	PipelineService = "Pipeline"
 )
 
 var urlMap = map[string]map[string]string{

--- a/pipelines.go
+++ b/pipelines.go
@@ -98,6 +98,9 @@ func migrateSpinnakerPipelines() error {
 		return err
 	}
 	pipelines, err = normalizeJsonArray(jsonBody)
+	if err != nil {
+		return err
+	}
 	payload := map[string][]map[string]interface{}{"pipelines": pipelines}
 	_, err = createSpinnakerPipelines(payload)
 	return err

--- a/prompts.go
+++ b/prompts.go
@@ -41,7 +41,6 @@ func PromptSecretDetails() (promptConfirm bool) {
 }
 
 func PromptConnectorDetails() (promptConfirm bool) {
-	promptConfirm = PromptEnvDetails()
 	promptConfirm = PromptSecretDetails()
 	if len(migrationReq.ConnectorScope) == 0 {
 		promptConfirm = true

--- a/update.go
+++ b/update.go
@@ -78,7 +78,7 @@ func readTar(body io.ReadCloser, dest string) error {
 		return err
 	}
 	reader := tar.NewReader(gzRead)
-	for true {
+	for {
 		header, err := reader.Next()
 		if err == io.EOF {
 			break


### PR DESCRIPTION
Most of this is just cleanup from issues discovered by staticcheck.

- `ioutil` was moved to `io` and was deprecated
- for `const` blocks, either type or don't. It will take the type of the value.
- `strings.TrimSuffix()` will return the same string if the suffix is not found. No need to search first.
- Calls to `fmt.Sprintf()` for errors did nothing. Logging as INFO for now unless you think they should be ERROR or FATAL
- pipelines.go ignored `err`. I assumed we want to return it. If not, just assign to `_`
- `for true {}` should be `for {}`

Only one I'm not entirely sure about is the change to `prompts.go`. If that call still needs to be made but we don't care about the output, just call it and don't assign the result. Or it may be that the author intended for something more like
```
promptConfirm = PromptEnvDetails() && PromptSecretDetails()
```
