### PR TITLE
fix:[ASSMT-167]: Moved Auth64 to Global Flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -352,6 +352,11 @@ func main() {
 			Usage:       "Specifies URL to the Spinnaker Gate service. Required when --platform is spinnaker.",
 			Destination: &migrationReq.SpinnakerAPIKey,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "auth64",
+			Usage:       "Base64 <username>:<password>  in case Spinnaker uses basic auth.",
+			Destination: &migrationReq.Auth64,
+		}),
 	}
 	app := &cli.App{
 		Name:                 "harness-upgrade",
@@ -429,11 +434,6 @@ func main() {
 						Name:        "app-name",
 						Usage:       "Specifies Spinnaker Application from which pipelines to be migrated.",
 						Destination: &migrationReq.SpinnakerAppName,
-					},
-					&cli.StringFlag{
-						Name:        "auth64",
-						Usage:       "Base64 <username>:<password>  in case Spinnaker uses basic auth.",
-						Destination: &migrationReq.Auth64,
 					},
 				},
 			},


### PR DESCRIPTION
fix:[ASSMT-167]: Moved Auth64 to Global Flags to fetch and use value from yml across the application.

<img width="1680" alt="Screenshot 2024-03-09 at 2 12 21 AM" src="https://github.com/harness/migrator/assets/140505097/70974d83-7573-4581-ae31-64662d51849d">


https://github.com/harness/migrator/assets/140505097/577b3e02-fc0a-414e-b08e-2d2bdb745bd1



[ASSMT-167]: https://harness.atlassian.net/browse/ASSMT-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ