### PR TITLE
fix:[ASSMT-167]: Updated Docs according to Ticket [ASSMT-167].

### DIFF
--- a/docs/docs/spinnaker-migration/instructions.md
+++ b/docs/docs/spinnaker-migration/instructions.md
@@ -23,11 +23,12 @@ secret-scope: project
 connector-scope: project
 template-scope: project
 workflow-scope: project
+auth64: AUTH_TOKEN
 ```
 
 ## Run command
 
-`harness-upgrade --load migrator-config.yml app --app-name prasadtest --auth64 YWRtaW46YWJjMTIz`
+`harness-upgrade --load migrator-config.yml app --app-name prasadtest`
 
 ## You should get output like this with some prompts:
 

--- a/docs/docs/spinnaker-migration/prerequisites.md
+++ b/docs/docs/spinnaker-migration/prerequisites.md
@@ -14,6 +14,6 @@ Before using the Spinnaker to CD Next Gen migration tool, you must have the foll
 
 - Harness Project - Project_Name
 
-- API Key - Follow instructions at Manage API keys | Harness Developer Hub 
+- API Key - Follow instructions at Manage API keys | [Harness Developer Hub](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/#create-personal-api-keys-and-tokens) 
 
 - Environment - Prod, Prod1, or Prod3


### PR DESCRIPTION
fix:[ASSMT-167]: Updated Docs according to Ticket [ASSMT-167].

As per the Pr #100 , we have shifted the Auth64 to global flag , so it can be directed fetched from the migrator-config.yml file itself , So there is no need to pass extra option via cli command .

Also updated the API Token Ref Link for Harness developer Hub

[ASSMT-167]: https://harness.atlassian.net/browse/ASSMT-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASSMT-167]: https://harness.atlassian.net/browse/ASSMT-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ