### PR TITLE
fix:[ASSMT-265]: Move app-name to Migrator config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ demo/
 .vscode
 
 harness-upgrade
+
+.DS_Store

--- a/app.go
+++ b/app.go
@@ -54,26 +54,25 @@ func migrateApp(*cli.Context) error {
 }
 
 func migrateSpinnakerApplication() error {
+	log.Info("Starting the migration of Spinnaker application")
 	authMethod := authBasic
 	if len(migrationReq.Cert) > 0 {
 		authMethod = authx509
 	}
-
+	log.Info("Importing the application....")
 	if len(migrationReq.SpinnakerHost) == 0 {
-		migrationReq.SpinnakerHost = TextInput("Please provide spinnaker host")
+		migrationReq.SpinnakerHost = TextInput("Please provide spinnaker host : ")
 	}
 	if len(migrationReq.SpinnakerAppName) == 0 {
-		migrationReq.SpinnakerAppName = TextInput("Please provide the Spinnaker application name")
+		migrationReq.SpinnakerAppName = TextInput("Please provide the Spinnaker application name : ")
 	}
-
-	log.Info("Importing the application....")
 	logSpinnakerMigrationDetails(authMethod)
-	confirm := ConfirmInput("Do you want to proceed with application migration?")
+	confirm := ConfirmInput("Do you want to proceed?")
 	if !confirm {
 		log.Fatal("Aborting...")
 	}
 	if len(migrationReq.ProjectIdentifier) == 0 {
-		migrationReq.ProjectIdentifier = TextInput("Name of the Project - ")
+		migrationReq.ProjectIdentifier = TextInput("Name of the Project : ")
 	}
 
 	jsonBody, err := getAllPipelines(authMethod)
@@ -97,8 +96,8 @@ func migrateSpinnakerApplication() error {
 		if len(id) > 0 {
 			log.Info("Project already exists with the given name")
 		} else {
-			log.Info("Creating the project....")
-			if err := createAProject("default", migrationReq.ProjectIdentifier, formatString(migrationReq.ProjectIdentifier)); err != nil {
+			log.Info("Creating project....")
+			if err := createAProject(migrationReq.OrgIdentifier, migrationReq.ProjectIdentifier, formatString(migrationReq.ProjectIdentifier)); err != nil {
 				log.Error(err)
 			}
 		}

--- a/docs/docs/spinnaker-migration/instructions.md
+++ b/docs/docs/spinnaker-migration/instructions.md
@@ -23,17 +23,19 @@ secret-scope: project
 connector-scope: project
 template-scope: project
 workflow-scope: project
+app-name: SpinnakerAppName
 auth64: AUTH_TOKEN
 ```
 
 ## Run command
 
-`harness-upgrade --load migrator-config.yml app --app-name SpinnakerAppName`
+`harness-upgrade --load migrator-config.yml app`
 
 ## You should get output like this with some prompts:
 
 ```shell
-`INFO[2024-03-04T15:50:38-08:00] Importing the application....                
+INFO[2024-03-04T15:50:38-08:00] Starting the migration of Spinnaker application                
+INFO[2024-03-04T15:50:38-08:00] Importing the application....                
 INFO[2024-03-04T15:50:38-08:00] 
 Migration details:
   Platform: spinnaker
@@ -42,6 +44,6 @@ Migration details:
   Pipeline Name: 
   Authentication method: basic 
   Insecure: false 
-? Do you want to proceed with application migration? Yes
-INFO[2024-03-04T15:50:41-08:00] Spinnaker migration completed`
+? Do you want to proceed? Yes
+INFO[2024-03-04T15:50:41-08:00] Spinnaker migration completed
 ```

--- a/main.go
+++ b/main.go
@@ -357,6 +357,11 @@ func main() {
 			Usage:       "Base64 <username>:<password>  in case Spinnaker uses basic auth.",
 			Destination: &migrationReq.Auth64,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "app-name",
+			Usage:       "Specifies Spinnaker Application from which pipelines to be migrated.",
+			Destination: &migrationReq.SpinnakerAppName,
+		}),
 	}
 	app := &cli.App{
 		Name:                 "harness-upgrade",
@@ -429,11 +434,6 @@ func main() {
 						Name:        "all",
 						Usage:       "if set will migrate all workflows & pipelines",
 						Destination: &migrationReq.AllAppEntities,
-					},
-					&cli.StringFlag{
-						Name:        "app-name",
-						Usage:       "Specifies Spinnaker Application from which pipelines to be migrated.",
-						Destination: &migrationReq.SpinnakerAppName,
 					},
 				},
 			},


### PR DESCRIPTION
**Fix for [ASSMT-265](https://harness.atlassian.net/browse/ASSMT-265): Move `app-name` to Migrator Config**

This pull request addresses the issue identified in [ASSMT-265], where the `app-name` command line prompt was moved to retrieve the value from the `migrator-config.yml` configuration file. In cases where the value is not found in the configuration file, the CLI will prompt the user to provide the Spinnaker application name.

Additionally, this fix includes updates to ensure proper project creation with the entered organization name. 

Moreover, optimizations have been made to enhance the formatting and clarity of the text messages displayed after running the CLI command. 

Furthermore, the documentation has been updated to reflect these changes accurately.

A video demonstration illustrating the flow has been attached to provide clarity and transparency regarding the implemented changes.

https://github.com/harness/migrator/assets/140505097/7467ecec-4b2e-4333-8a27-c103484ef29d



[ASSMT-265]: https://harness.atlassian.net/browse/ASSMT-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASSMT-265]: https://harness.atlassian.net/browse/ASSMT-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ