### PR TITLE
fix:[ASSMT-251]: Pipeline migration cli cleanup

### DIFF
--- a/docs/docs/spinnaker-migration/advance.md
+++ b/docs/docs/spinnaker-migration/advance.md
@@ -1,0 +1,21 @@
+# Advance Commands
+
+## 1. Import Spinnaker pipeline to existing project
+`
+harness-upgrade --load migrator-config.yml pipelines --pipeline-name pipeline_name import
+`
+### You should get output like this with some prompts:
+```shell
+INFO[2024-03-04T15:50:38-08:00] Importing the application....
+INFO[2024-03-04T15:50:38-08:00]
+Migration details:
+  Platform: spinnaker
+  Spinnaker Host: harness-eval.dynamo-staging.eng.armory.io
+  App name: prasadtest
+  Pipeline Name: pipeline_name
+  Authentication method: basic 
+  Insecure: false 
+? Do you want to proceed with pipeline migration? Yes
+INFO[2024-03-04T15:50:41-08:00] Spinnaker pipeline migration completed
+```
+

--- a/main.go
+++ b/main.go
@@ -583,11 +583,6 @@ func main() {
 						Destination: &migrationReq.Names,
 					},
 					&cli.StringFlag{
-						Name:        "app-name",
-						Usage:       "Specifies Spinnaker Application from which pipelines to be migrated.",
-						Destination: &migrationReq.SpinnakerAppName,
-					},
-					&cli.StringFlag{
 						Name:        "pipeline-name",
 						Usage:       "Specifies Spinnaker Pipeline which to be migrated.",
 						Destination: &migrationReq.PipelineName,
@@ -606,11 +601,6 @@ func main() {
 						Name:        "key",
 						Usage:       "Optional. key file location in case Spinnaker uses x509 auth",
 						Destination: &migrationReq.Key,
-					},
-					&cli.StringFlag{
-						Name:        "auth64",
-						Usage:       "Base64 <username>:<password>  in case Spinnaker uses basic auth.",
-						Destination: &migrationReq.Auth64,
 					},
 				},
 				Subcommands: []*cli.Command{

--- a/pipelines.go
+++ b/pipelines.go
@@ -69,16 +69,15 @@ func migrateSpinnakerPipelines() error {
 	if len(migrationReq.Cert) > 0 {
 		authMethod = authx509
 	}
-
+	log.Info("Importing the application....")
 	if len(migrationReq.SpinnakerHost) == 0 {
-		migrationReq.SpinnakerHost = TextInput("Please provide spinnaker host")
+		migrationReq.SpinnakerHost = TextInput("Please provide spinnaker host : ")
 	}
 	if len(migrationReq.SpinnakerAppName) == 0 {
-		migrationReq.SpinnakerAppName = TextInput("Please provide the Spinnaker application name")
+		migrationReq.SpinnakerAppName = TextInput("Please provide the Spinnaker application name : ")
 	}
-
-	if !migrationReq.All {
-		migrationReq.PipelineName = TextInput("Please provide the Spinnaker pipeline name")
+	if len(migrationReq.PipelineName) == 0 {
+		migrationReq.PipelineName = TextInput("Please provide the Spinnaker pipeline name : ")
 	}
 
 	logSpinnakerMigrationDetails(authMethod)


### PR DESCRIPTION
Fix for [ASSMT-251](https://harness.atlassian.net/browse/ASSMT-251): Pipeline migration cli cleanup 

This pull request addresses the issue identified in [ASSMT-251](https://harness.atlassian.net/browse/ASSMT-251), where the `auth64` ref: #100 command line prompt was moved to retrieve the value from the migrator-config.yml configuration file for the pipeline command. In cases where the value is not found in the cli prompt, the CLI will prompt the user to provide the Spinnaker pipeline name.

Moreover, optimizations have been made to enhance the formatting and clarity of the text messages displayed after running the CLI command.

Furthermore, the documentation has been updated to reflect these changes accurately.

A video demonstration illustrating the flow has been attached to provide clarity and transparency regarding the implemented changes.

https://github.com/harness/migrator/assets/140505097/2b377a81-0c42-4f32-aebe-b86ef9ef8aff



[ASSMT-251]: https://harness.atlassian.net/browse/ASSMT-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASSMT-251]: https://harness.atlassian.net/browse/ASSMT-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ