### PR TITLE
Add Support for DevSpace

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -25,6 +25,7 @@ const (
 	Dev         = "Dev"
 	Prod3       = "Prod3"
 	SelfManaged = "SelfManaged"
+	DevSpace    = "DevSpace"
 )
 
 const (
@@ -33,6 +34,8 @@ const (
 	TemplateService = "Template"
 	PipelineService = "Pipeline"
 )
+
+var host = os.Getenv("HOST_NAME")
 
 var urlMap = map[string]map[string]string{
 	Prod: {
@@ -58,6 +61,12 @@ var urlMap = map[string]map[string]string{
 		TemplateService: "https://app3.harness.io/gateway/template",
 		MigratorService: "https://app3.harness.io/gateway/ng-migration/api/ng-migration",
 		NextGenService:  "https://app3.harness.io/gateway/ng",
+	},
+	DevSpace: {
+		PipelineService: "https://" + host + ".pr2.harness.io/gateway/pipeline",
+		TemplateService: "https://" + host + ".pr2.harness.io/gateway/template",
+		MigratorService: "https://" + host + ".pr2.harness.io/gateway/ng-migration/api/ng-migration",
+		NextGenService:  "https://" + host + ".pr2.harness.io/gateway/ng",
 	},
 }
 
@@ -327,6 +336,9 @@ func GetBaseUrl(environment string, service string) string {
 		environment = "Prod"
 	}
 	if environment != SelfManaged {
+		if len(host) == 0 && environment == DevSpace {
+			log.Fatal("HOST_NAME env variable is not set for DevSpace Environment")
+		}
 		url := urlMap[environment][service]
 		if len(url) == 0 {
 			log.Fatalf("invalid environment value - %s", environment)


### PR DESCRIPTION
Adding support for migrator to run against DevSpace also.

Env Variable : `HOST_NAME` ( Namespace of your devspace, ex : migratortest , ritek)

<img width="1728" alt="Screenshot 2024-06-19 at 11 20 15 PM" src="https://github.com/harness/migrator/assets/140505097/64baa3a3-1b4b-4eb5-b1ea-27486f2870ed">
<img width="1728" alt="Screenshot 2024-06-19 at 11 20 27 PM" src="https://github.com/harness/migrator/assets/140505097/50d44a0c-6d38-4cfe-963c-f3937ff6f726">
