### PR TITLE
feat: [ASSMT-410]: Create Org variable for Plugin

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -382,6 +382,10 @@ func createSpinnakerPipelines(pipelines interface{}) (reqId string, err error) {
 	if err != nil {
 		return "", err
 	}
+	err = CheckOrgVariableExistsAndCreate()
+	if err != nil {
+		return "", err
+	}
 	j, err := json.MarshalIndent(pipelines, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal pipelines JSON: %v", err)

--- a/types.go
+++ b/types.go
@@ -261,3 +261,26 @@ type ProjectCSV struct {
 	ProjectIdentifier string `json:"projectIdentifier"`
 	OrgIdentifier     string `json:"orgIdentifier"`
 }
+
+type VariableDetails struct {
+	Identifier    string       `json:"identifier"`
+	Name          string       `json:"name"`
+	OrgIdentifier string       `json:"orgIdentifier"`
+	Type          string       `json:"type"`
+	Description   string       `json:"description"`
+	VariableSpec  VariableSpec `json:"spec"`
+}
+
+type VariableSpec struct {
+	ValueType    string `json:"valueType"`
+	FixedValue   string `json:"fixedValue"`
+	DefaultValue string `json:"defaultValue"`
+	Value        string `json:"value"`
+}
+
+type VariableListBody struct {
+	Variables []VariableBody `json:"content"`
+}
+type VariableBody struct {
+	Variable VariableDetails `json:"variable"`
+}


### PR DESCRIPTION
Added a method to create a `Org` Level variables for the plugin with dynamically fetching the tag from docker hub.

```java
{"harnessawsdroneplugin", "aws-drone-plugin"}
{"harnessbakedeployplugin", "aws-bake-deploy-ami-plugin"}
```
<img width="1271" alt="image" src="https://github.com/harness/migrator/assets/140505097/59b6da0a-e4a1-40dc-a830-45a968ca9948">
