### PR TITLE
feat: [ASSMT-651]: show migrated entities summary

### DIFF
--- a/app.go
+++ b/app.go
@@ -90,12 +90,11 @@ func migrateSpinnakerApplication() error {
 		return nil
 	}
 
-	payload := map[string][]map[string]interface{}{"pipelines": pipelines}
-
-	stages, _ := getSupportedStages()
-	if stages != nil {
-		checkUnsupportedStages(payload, stages)
+	dryRun := migrationReq.DryRun
+	payload := map[string]interface{}{
+		"pipelines": pipelines, // Expecting pipelines as []map[string]interface{}
+		"dryRun":    dryRun,    // dryRun as a bool
 	}
-	_, err = createSpinnakerPipelines(payload)
+	_, err = createSpinnakerPipelines(payload, dryRun)
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -387,6 +387,11 @@ func main() {
 			Usage:       "x509 key location for authenticating with spinnaker",
 			Destination: &migrationReq.Key,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:        "dryRun",
+			Usage:       "perform a dry run without side effects",
+			Destination: &migrationReq.DryRun,
+		}),
 	}
 	app := &cli.App{
 		Name:                 "harness-upgrade",
@@ -588,6 +593,11 @@ func main() {
 				Usage: "Import pipelines into an existing project by providing the `appId` & `pipelineIds`",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
+						Name:        "dryRun",
+						Usage:       "dry run",
+						Destination: &migrationReq.DryRun,
+					},
+					&cli.BoolFlag{
 						Name:        "all",
 						Usage:       "all pipelines",
 						Destination: &migrationReq.All,
@@ -619,7 +629,7 @@ func main() {
 					},
 					&cli.BoolFlag{
 						Name:        "insecure",
-						Usage:       "Weteher to validate the TLS certificate or not",
+						Usage:       "Whether to validate the TLS certificate or not",
 						Destination: &migrationReq.AllowInsecureReq,
 					},
 					&cli.StringFlag{

--- a/types.go
+++ b/types.go
@@ -191,12 +191,25 @@ type MigrationStats struct {
 }
 
 type Resource struct {
-	RequestId       string                    `json:"requestId"`
-	Stats           map[string]MigrationStats `json:"stats"`
-	Errors          []UpgradeError            `json:"errors"`
-	Status          string                    `json:"status"`
-	ResponsePayload interface{}               `json:"responsePayload"`
-	SkipDetails     []NGSkipDetail            `json:"skipDetails"`
+	RequestId                   string                       `json:"requestId"`
+	Stats                       map[string]MigrationStats    `json:"stats"`
+	Errors                      []UpgradeError               `json:"errors"`
+	Status                      string                       `json:"status"`
+	ResponsePayload             interface{}                  `json:"responsePayload"`
+	SkipDetails                 []NGSkipDetail               `json:"skipDetails"`
+	SuccessfullyMigratedDetails []SuccessfullyMigratedDetail `json:"successfullyMigratedDetails"`
+}
+
+type SuccessfullyMigratedDetail struct {
+	CgEntityDetail interface{}    `json:"cgEntityDetail"` // Assuming cgEntityDetail can be nil or of a specific type
+	NgEntityDetail NgEntityDetail `json:"ngEntityDetail"`
+}
+
+type NgEntityDetail struct {
+	EntityType        string `json:"entityType"`
+	Identifier        string `json:"identifier"`
+	OrgIdentifier     string `json:"orgIdentifier"`
+	ProjectIdentifier string `json:"projectIdentifier"`
 }
 
 type ResponseBody struct {


### PR DESCRIPTION
Sample output:
```
WARN[2024-11-11T01:18:44-06:00] 
 Pipeline with id: dev
 has unsupported Stages:
  - jetPreflight
  - jetDeploymentTargetOnboarding 
INFO[2024-11-11T01:18:44-06:00] created entity:
  EntityType: SERVICE
  Identifier: k8spolitezebra56
  OrgIdentifier: default
  ProjectIdentifier: jpmc 
INFO[2024-11-11T01:18:44-06:00] created entity:
  EntityType: ENVIRONMENT
  Identifier: envpolitezebra56
  OrgIdentifier: default
  ProjectIdentifier: jpmc 
INFO[2024-11-11T01:18:44-06:00] created entity:
  EntityType: ENVIRONMENT
  Identifier: envdeploydev2
  OrgIdentifier: default
  ProjectIdentifier: jpmc 
INFO[2024-11-11T01:18:44-06:00] created entity:
  EntityType: INFRA
  Identifier: infrapolitezebra56
  OrgIdentifier: default
  ProjectIdentifier: jpmc 
INFO[2024-11-11T01:18:44-06:00] created entity:
  EntityType: PIPELINE
  Identifier: dev
  OrgIdentifier: default
  ProjectIdentifier: jpmc 
INFO[2024-11-11T01:18:44-06:00] Note: This was a dry run of the spinnaker migration 

```