### PR TITLE
Support dry run and plan in spinnaker migration

### DIFF
--- a/app.go
+++ b/app.go
@@ -91,9 +91,11 @@ func migrateSpinnakerApplication() error {
 	}
 
 	dryRun := migrationReq.DryRun
+	plan := migrationReq.Plan
 	payload := map[string]interface{}{
 		"pipelines": pipelines, // Expecting pipelines as []map[string]interface{}
 		"dryRun":    dryRun,    // dryRun as a bool
+		"planOnly":  plan,
 	}
 	_, err = createSpinnakerPipelines(payload, dryRun)
 	return err

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var migrationReq = struct {
 	UrlNG                 string `survey:"urlNG"`
 	UrlCG                 string `survey:"urlCG"`
 	DryRun                bool   `survey:"dryRun"`
+	Plan                  bool   `survey:"plan"`
 	FileExtensions        string `survey:"fileExtensions"`
 	CustomExpressionsFile string `survey:"customExpressionsFile"`
 	CustomStringsFile     string `survey:"customStringsFile"`
@@ -392,6 +393,11 @@ func main() {
 			Usage:       "perform a dry run without side effects",
 			Destination: &migrationReq.DryRun,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:        "plan",
+			Usage:       "gets the harness entities as yaml",
+			Destination: &migrationReq.DryRun,
+		}),
 	}
 	app := &cli.App{
 		Name:                 "harness-upgrade",
@@ -596,6 +602,11 @@ func main() {
 						Name:        "dryRun",
 						Usage:       "dry run",
 						Destination: &migrationReq.DryRun,
+					},
+					&cli.BoolFlag{
+						Name:        "plan",
+						Usage:       "shows the entities as yaml",
+						Destination: &migrationReq.Plan,
 					},
 					&cli.BoolFlag{
 						Name:        "all",

--- a/types.go
+++ b/types.go
@@ -203,6 +203,7 @@ type Resource struct {
 type SuccessfullyMigratedDetail struct {
 	CgEntityDetail interface{}    `json:"cgEntityDetail"` // Assuming cgEntityDetail can be nil or of a specific type
 	NgEntityDetail NgEntityDetail `json:"ngEntityDetail"`
+	AdditionalInfo string         `json:"additionalInfo"`
 }
 
 type NgEntityDetail struct {


### PR DESCRIPTION
Example usage:
`./harness-upgrade --project jpmc --org default --pipeline-json "sample-pipeline-jpmc.json" --platform spinnaker --spinnaker-host spinnaker-api.internal.armory.io:8443 --account xoFJwM3DQ7yQ7tPZvGGlkw pipelines -dryRun -plan import`

It creates harness yaml files under a project folder 